### PR TITLE
Run integration tests in container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,7 @@ jobs:
     - stage: test_integration
       language: node_js
       name: Test Integration
+      node_js:
+        - 10.16.3
       script: make test_integration
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
 
 stages:
   - test
-  - build
 
 jobs:
   include:
@@ -18,20 +17,12 @@ jobs:
       script:
         - make lint
         - make test
-
-    - stage: build
-      name: Build
-      script: make build
+        - make build
+        - make test_integration
       deploy:
         provider: script
         script: make push
         on:
           branch: master
 
-    - stage: test_integration
-      language: node_js
-      name: Test Integration
-      node_js:
-        - 10.16.3
-      script: make test_integration
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ jobs:
       script:
         - make lint
         - make test
-        - make test_integration
 
     - stage: build
       name: Build
@@ -28,4 +27,9 @@ jobs:
         script: make push
         on:
           branch: master
+
+    - stage: test_integration
+      language: node_js
+      name: Test Integration
+      script: make test_integration
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY  tsconfig.build.json \
       ./
 
 COPY src/ ./src/
+COPY tests/config.json ./tests/config.json
 RUN yarn &&\
     yarn build
 
@@ -26,10 +27,13 @@ WORKDIR /app
 
 COPY --from=source /app/node_modules/ ./node_modules/
 COPY --from=source /app/dist/ ./dist/
+COPY --from=source /app/tests/config.json ./tests/config.json
 
-EXPOSE 3000
+RUN apk add curl
+
+EXPOSE 3004
 
 HEALTHCHECK --interval=1m --timeout=1s \
-	CMD curl -f http://localhost:3000/health || exit 1
+	CMD curl -f http://localhost:3004/health || exit 1
 
 CMD ["node", "dist/main.js"]

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ test_integration:
 	./.scripts/docker/wait-healthy.sh test_rabbitmq 20
 	${DOCKER_COMPOSE_TEST} up -d audit
 	./.scripts/docker/wait-healthy.sh test_audit 20
+	${DOCKER_COMPOSE_TEST} exec audit node dist/migrate.js run
 	CONFIG_PATH=./tests/config.json yarn test:integration
 	${DOCKER_COMPOSE_TEST} down
 	

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,11 @@ test: get_deps
 
 test_integration:
 	- ${DOCKER_COMPOSE_TEST} down -v
-	${DOCKER_COMPOSE_TEST} up -d
+	${DOCKER_COMPOSE_TEST} up -d postgres rabbitmq
+	./.scripts/docker/wait-healthy.sh audit_postgres_1 20
+	./.scripts/docker/wait-healthy.sh audit_rabbitmq_1 20
+	${DOCKER_COMPOSE_TEST} up -d audit
+	./.scripts/docker/wait-healthy.sh audit_audit_1 20
 	CONFIG_PATH=./tests/config.json yarn test:integration
 	${DOCKER_COMPOSE_TEST} down -v
 	

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,8 @@ test: get_deps
 
 test_integration:
 	- ${DOCKER_COMPOSE_TEST} down -v
-	${DOCKER_COMPOSE_TEST} up -d postgres
-	CONFIG_PATH=./tests/config.json yarn migrate run
-	CONFIG_PATH=./tests/config.json yarn test:integration --detectOpenHandles
+	${DOCKER_COMPOSE_TEST} up -d
+	CONFIG_PATH=./tests/config.json yarn test:integration
 	${DOCKER_COMPOSE_TEST} down -v
 	
 build:

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ test: get_deps
 test_integration:
 	- ${DOCKER_COMPOSE_TEST} down -v
 	${DOCKER_COMPOSE_TEST} up -d postgres rabbitmq
-	./.scripts/docker/wait-healthy.sh audit_postgres_1 20
-	./.scripts/docker/wait-healthy.sh audit_rabbitmq_1 20
+	./.scripts/docker/wait-healthy.sh audit_postgres_1 60
+	./.scripts/docker/wait-healthy.sh audit_rabbitmq_1 60
 	${DOCKER_COMPOSE_TEST} up -d audit
-	./.scripts/docker/wait-healthy.sh audit_audit_1 20
+	./.scripts/docker/wait-healthy.sh audit_audit_1 60
 	CONFIG_PATH=./tests/config.json yarn test:integration
 	${DOCKER_COMPOSE_TEST} down -v
 	

--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,10 @@ test: get_deps
 test_integration:
 	- ${DOCKER_COMPOSE_TEST} down -v
 	${DOCKER_COMPOSE_TEST} up -d postgres rabbitmq
-	./.scripts/docker/wait-healthy.sh audit_postgres_1 60
-	./.scripts/docker/wait-healthy.sh audit_rabbitmq_1 60
+	./.scripts/docker/wait-healthy.sh test_postgres 20
+	./.scripts/docker/wait-healthy.sh test_rabbitmq 20
 	${DOCKER_COMPOSE_TEST} up -d audit
-	./.scripts/docker/wait-healthy.sh audit_audit_1 60
+	./.scripts/docker/wait-healthy.sh test_audit 20
 	CONFIG_PATH=./tests/config.json yarn test:integration
 	${DOCKER_COMPOSE_TEST} down -v
 	

--- a/Makefile
+++ b/Makefile
@@ -17,14 +17,14 @@ test: get_deps
 	yarn test
 
 test_integration:
-	- ${DOCKER_COMPOSE_TEST} down -v
+	- ${DOCKER_COMPOSE_TEST} down
 	${DOCKER_COMPOSE_TEST} up -d postgres rabbitmq
 	./.scripts/docker/wait-healthy.sh test_postgres 20
 	./.scripts/docker/wait-healthy.sh test_rabbitmq 20
 	${DOCKER_COMPOSE_TEST} up -d audit
 	./.scripts/docker/wait-healthy.sh test_audit 20
 	CONFIG_PATH=./tests/config.json yarn test:integration
-	${DOCKER_COMPOSE_TEST} down -v
+	${DOCKER_COMPOSE_TEST} down
 	
 build:
 	${DOCKER_COMPOSE} build audit 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -38,13 +38,8 @@ services:
     container_name: test_postgres
     ports:
       - "5432:5432"
-    volumes:
-      - pg-data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 2s
       timeout: 30s
       retries: 10
-
-volumes:
-  pg-data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   audit:
-    image: liberoadmin/audit:latest
+    image: libero/audit:local
     container_name: test_audit
     ports:
       - "${AUDIT_PORT:-3004}:3004"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   audit:
-    image: libero/audit:local
+    image: libero/audit:latest
     container_name: test_audit
     ports:
       - "${AUDIT_PORT:-3004}:3004"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,14 +1,14 @@
 version: '3'
 services:
   audit:
-    image: liberoadmin/audit:${IMAGE_TAG}
+    image: libero/audit:local
     container_name: test_audit
     ports:
       - "${AUDIT_PORT:-3004}:3004"
     environment:
       CONFIG_PATH: ./tests/config.json
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3004/health" ]
+      test: "curl localhost:3004/health"
       interval: 2s
       timeout: 30s
       retries: 10

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   audit:
     image: node:10
+    container_name: test_audit
     ports:
       - "${AUDIT_PORT:-3004}:3004"
     working_dir: "/src"
@@ -22,6 +23,7 @@ services:
 
   rabbitmq:
     image: rabbitmq:3-management
+    container_name: test_rabbitmq
     ports:
       - "15672:15672"
       - "5672:5672"
@@ -33,6 +35,7 @@ services:
 
   postgres:
     image: postgres:11
+    container_name: test_postgres
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   audit:
-    image: libero/audit:latest
+    image: libero/audit:${IMAGE_TAG:-local}
     container_name: test_audit
     ports:
       - "${AUDIT_PORT:-3004}:3004"

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,17 +1,12 @@
 version: '3'
 services:
   audit:
-    image: node:10
+    image: liberoadmin/audit:${IMAGE_TAG}
     container_name: test_audit
     ports:
       - "${AUDIT_PORT:-3004}:3004"
-    working_dir: "/src"
-    command: ["bash", "-c", "yarn && yarn run migrate run &&yarn run start:dev"]
     environment:
       CONFIG_PATH: ./tests/config.json
-    volumes:
-      - ./:/src/:z
-      - ./config/:/etc/reviewer/:z
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:3004/health" ]
       interval: 2s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,25 +5,43 @@ services:
     ports:
       - "${AUDIT_PORT:-3004}:3004"
     working_dir: "/src"
-    command: ["bash", "-c", "yarn && yarn run migrate run && yarn run start:dev"]
+    command: ["bash", "-c", "yarn && yarn run migrate run &&yarn run start:dev"]
     environment:
       CONFIG_PATH: ./tests/config.json
     volumes:
       - ./:/src/:z
       - ./config/:/etc/reviewer/:z
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3004/health" ]
+      interval: 2s
+      timeout: 30s
+      retries: 10
+    depends_on:
+      - rabbitmq
+      - postgres
 
   rabbitmq:
     image: rabbitmq:3-management
     ports:
       - "15672:15672"
       - "5672:5672"
+    healthcheck:
+      test: [ "CMD", "rabbitmqctl", "status" ]
+      interval: 2s
+      timeout: 30s
+      retries: 10
 
   postgres:
     image: postgres:11
     ports:
-       - "5432:5432"
+      - "5432:5432"
     volumes:
-       - pg-data:/var/lib/postgresql/data
+      - pg-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 30s
+      retries: 10
 
 volumes:
   pg-data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,23 @@
 version: '3'
 services:
+  audit:
+    image: node:10
+    ports:
+      - "${AUDIT_PORT:-3004}:3004"
+    working_dir: "/src"
+    command: ["bash", "-c", "yarn && yarn run migrate run && yarn run start:dev"]
+    environment:
+      CONFIG_PATH: ./tests/config.json
+    volumes:
+      - ./:/src/:z
+      - ./config/:/etc/reviewer/:z
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "15672:15672"
+      - "5672:5672"
+
   postgres:
     image: postgres:11
     ports:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   audit:
-    image: libero/audit:local
+    image: liberoadmin/audit:latest
     container_name: test_audit
     ports:
       - "${AUDIT_PORT:-3004}:3004"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  application:
+  audit:
     image: node:10
     ports:
       - "${AUDIT_PORT:-3004}:3004"
@@ -18,9 +18,6 @@ services:
       - "infra_rabbit"
 
 networks:
-  infra_api:
-    external:
-      name: "infra_api"
   infra_rabbit:
     external:
       name: "infra_rabbit"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "libero-npm@elifesciences.org",
   "license": "MIT",
   "dependencies": {
-    "@libero/event-bus": "^0.1.3",
+    "@libero/event-bus": "^0.2.0",
     "@libero/event-types": "^0.1.0",
     "@libero/migrator": "^0.1.0",
     "express": "^4.17.1",

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -10,6 +10,8 @@ export type EventHandler<T extends object> = (...args) => (ev: Event<T>) => Prom
 export const UserLoggedInHandler = (auditDomain: AuditController) => async (
     event: Event<UserLoggedInPayload>,
 ): Promise<boolean> => {
+    // await new Promise(resolve => setTimeout(resolve, 2000));
+
     const auditItem: AuditLogItem = {
         entity: `user:${event.payload.userId}`,
         action: 'LOGGED_IN',

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -10,8 +10,6 @@ export type EventHandler<T extends object> = (...args) => (ev: Event<T>) => Prom
 export const UserLoggedInHandler = (auditDomain: AuditController) => async (
     event: Event<UserLoggedInPayload>,
 ): Promise<boolean> => {
-    // await new Promise(resolve => setTimeout(resolve, 2000));
-
     const auditItem: AuditLogItem = {
         entity: `user:${event.payload.userId}`,
         action: 'LOGGED_IN',

--- a/src/migrate.ts
+++ b/src/migrate.ts
@@ -7,7 +7,7 @@ const cli = new Cli({
     knexConfig: getServiceConfig().knex,
     migrations: {
         path: `${__dirname}/migrations`,
-        pattern: /.*\.ts/,
+        pattern: /.*\.js$/,
     },
 });
 

--- a/tests/config.json
+++ b/tests/config.json
@@ -4,7 +4,7 @@
     "database": {
         "type": "pg",
         "name": "postgres",
-        "host": "localhost",
+        "host": "postgres",
         "username": "postgres",
         "database": "postgres",
         "port": 5432

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,14 +291,14 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@libero/event-bus@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@libero/event-bus/-/event-bus-0.1.3.tgz#b077c5443d2d2788907844e57cf705c5a1f8c6a7"
-  integrity sha512-nebE4j8bjOEhCBSpAX+m7wSRtkEic+j0tMeRjCa4BDgaaD73tTfkq67fXUN0MIK1Ov3I0V8+DlqnGOSvy58Rrw==
+"@libero/event-bus@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@libero/event-bus/-/event-bus-0.2.0.tgz#254cf79268f3413740f41d1d9d6ba0c83e58b1d2"
+  integrity sha512-GN7e6e2HZo5rK4Yqykf3OpT95HOZlTNoiRt2vItiZhIN4V+1tmnYuaJJi0n8PVYaytyyfjIwLBgMiFAeQ/LSTw==
   dependencies:
     "@types/amqplib" "^0.5.13"
     "@types/jest" "^24.0.18"
-    "@types/pino" "^5.8.10"
+    "@types/pino" "^5.14.0"
     "@types/uuid" "^3.4.5"
     amqplib "^0.5.5"
     funfix "^7.0.1"
@@ -494,7 +494,7 @@
   resolved "https://registry.yarnpkg.com/@types/pino-std-serializers/-/pino-std-serializers-2.4.0.tgz#8cad99175cb79c2448f7455a2d32fb3fde29579c"
   integrity sha512-eAdu+NW1IkCdmp85SnhyKha+OOREQMT9lXaoICQxa7bhSauRiLzu3WSNt9Mf2piuJvWeXF/G0hGWHr63xNpIRA==
 
-"@types/pino@^5.8.10":
+"@types/pino@^5.14.0", "@types/pino@^5.8.10":
   version "5.14.0"
   resolved "https://registry.yarnpkg.com/@types/pino/-/pino-5.14.0.tgz#e5226bf6d5da52e2d6b641309abee5f30b2d7a56"
   integrity sha512-i4jTU0G9HL/wy7WbVMqcM/5Z6cFzbcLN6/T46rqQauIoiDqcEySR7SN4FfJvtv+RoBtJkQjDneq0Ytrj95cQHg==


### PR DESCRIPTION
Closes #17 

Modify the integration tests with audit running in a container, along with real rabbitmq service as well.

Problems encountered:
-  ~~Events are now asynchronously received so we need artificial wait until we check the database~~
-  ~~Sometimes audit container hasn't finished starting and integration is already under way, causing errors~~